### PR TITLE
Remove deprecated configureondemand setting to eliminate build warning

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -7,7 +7,6 @@ org.gradle.jvmargs=-Xmx2048m -Dfile.encoding=UTF-8
 org.gradle.daemon=true
 org.gradle.parallel=true
 org.gradle.caching=true
-org.gradle.configureondemand=true
 
 # AndroidX
 android.useAndroidX=true


### PR DESCRIPTION
# Remove Deprecated Gradle Configuration Warning

## What's Changed

- Removed `org.gradle.configureondemand=true` from `gradle.properties`

## Why

This setting is deprecated and caused the "Configuration on demand is an incubating feature" warning on every build. Removing it eliminates the warning while maintaining build performance through other optimizations (daemon, parallel execution, caching).

## Result

Clean builds with no configuration warnings.
